### PR TITLE
Code fixes

### DIFF
--- a/restaurant-client-lab/src/main/java/org/a4j/restaurant/client/BeanValidationExceptionMapper.java
+++ b/restaurant-client-lab/src/main/java/org/a4j/restaurant/client/BeanValidationExceptionMapper.java
@@ -1,4 +1,4 @@
-package org.a4j.restaurant.client.infra;
+package org.a4j.restaurant.client;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;

--- a/restaurant-client-lab/src/main/java/org/a4j/restaurant/client/FieldPropertyVisibilityStrategy.java
+++ b/restaurant-client-lab/src/main/java/org/a4j/restaurant/client/FieldPropertyVisibilityStrategy.java
@@ -1,4 +1,4 @@
-package org.a4j.restaurant.client.infra;
+package org.a4j.restaurant.client;
 
 import javax.json.bind.config.PropertyVisibilityStrategy;
 import java.lang.reflect.Field;

--- a/restaurant-client-lab/src/main/java/org/a4j/restaurant/client/Ingredient.java
+++ b/restaurant-client-lab/src/main/java/org/a4j/restaurant/client/Ingredient.java
@@ -1,7 +1,5 @@
 package org.a4j.restaurant.client;
 
-import org.a4j.restaurant.client.infra.FieldPropertyVisibilityStrategy;
-
 import javax.json.bind.annotation.JsonbVisibility;
 
 @JsonbVisibility(FieldPropertyVisibilityStrategy.class)
@@ -39,6 +37,4 @@ public class Ingredient {
         this.unit = unit;
         this.quantity = quantity;
     }
-
-    public Ingredient(){}
 }

--- a/restaurant-client-lab/src/main/java/org/a4j/restaurant/client/Item.java
+++ b/restaurant-client-lab/src/main/java/org/a4j/restaurant/client/Item.java
@@ -1,8 +1,6 @@
 package org.a4j.restaurant.client;
 
 
-import org.a4j.restaurant.client.infra.FieldPropertyVisibilityStrategy;
-
 import javax.json.bind.annotation.JsonbVisibility;
 import java.time.LocalDate;
 import java.util.Collections;
@@ -40,7 +38,7 @@ public class Item {
     }
 
     public List<Ingredient> getIngredients() {
-        if(Objects.isNull(this.ingredients)) {
+        if (Objects.isNull(this.ingredients)) {
             return Collections.emptyList();
         }
         return this.ingredients;

--- a/restaurant/src/main/java/org/a4j/restaurant/Ingredient.java
+++ b/restaurant/src/main/java/org/a4j/restaurant/Ingredient.java
@@ -25,6 +25,9 @@ public class Ingredient {
         return quantity;
     }
 
+    public Ingredient() {
+    }
+
     public Ingredient(String name, String unit, double quantity) {
         this.name = name;
         this.unit = unit;

--- a/restaurant/src/main/java/org/a4j/restaurant/Item.java
+++ b/restaurant/src/main/java/org/a4j/restaurant/Item.java
@@ -62,10 +62,13 @@ public class Item {
     }
 
     public List<Ingredient> getIngredients() {
-        if(Objects.isNull(this.ingredients)) {
+        if (Objects.isNull(this.ingredients)) {
             return Collections.emptyList();
         }
         return this.ingredients;
+    }
+
+    public Item() {
     }
 
     public Item(String name, String description, ItemType type, LocalDate expires, List<Ingredient> ingredients) {


### PR DESCRIPTION
* 1st module `restaurant`:
Add default constructor to Ingredient and Item, because of e.g. 
```
Caused by: javax.json.bind.JsonbException: Cannot create instance of a class: class org.a4j.restaurant.Ingredient, No default constructor found.
	at org.eclipse.yasson.internal.serializer.ObjectDeserializer.getInstance(ObjectDeserializer.java:101)
	at org.eclipse.yasson.internal.serializer.AbstractContainerDeserializer.deserialize(AbstractContainerDeserializer.java:65)
	at org.eclipse.yasson.internal.serializer.CollectionDeserializer.deserializeNext(CollectionDeserializer.java:117)
	at org.eclipse.yasson.internal.serializer.AbstractContainerDeserializer.deserializeInternal(AbstractContainerDeserializer.java:94)
	at org.eclipse.yasson.internal.serializer.AbstractContainerDeserializer.deserialize(AbstractContainerDeserializer.java:64)
	at org.eclipse.yasson.internal.serializer.ObjectDeserializer.deserializeNext(ObjectDeserializer.java:180)
	at org.eclipse.yasson.internal.serializer.AbstractContainerDeserializer.deserializeInternal(AbstractContainerDeserializer.java:94)
	... 39 more

```

and 
```
Caused by: javax.json.bind.JsonbException: Cannot create instance of a class: class org.a4j.restaurant.Item, No default constructor found.
[...]
```

Above error reproducible (JDK11 and JDK17) with:
```
curl --location --request POST 'http://localhost:8080/restaurants' \
--header 'Content-Type: application/json' \
--data-raw '{"name": "water", "description": "Water appears as a clear, nontoxic liquid composed of hydrogen and oxygen, essential for life.", "type": "BEVERAGE",
"expires": "2025-12-03", "ingredients": [{"name": "water", "unit": "L", "quantity": 2}]}'
```
