### PR TITLE
Fix #1  Update doesn't work on acme golden API.

### DIFF
--- a/acme-store-rest/src/main/java/org/a4j/product/ProductMicrostreamRepository.java
+++ b/acme-store-rest/src/main/java/org/a4j/product/ProductMicrostreamRepository.java
@@ -18,7 +18,12 @@ public class ProductMicrostreamRepository {
 
     public Product save(Product product) {
         Objects.requireNonNull(product, "Product is required");
-        this.products.add(product);
+
+        if (!products.add(product)) {
+            deleteById(product.getName());
+            products.add(product);
+        }
+
         return product;
     }
 


### PR DESCRIPTION
From `Set.add()` Javadoc:
```
Adds the specified element to this set if it is not already present (optional operation). More formally, adds the specified element e to this set if the set contains no element e2 such that Objects.equals(e, e2). If this set already contains the element, the call leaves the set unchanged and returns false.
```

Since `Product` defines its `equals()` based on `name` field, the return code of `add()` must be evaluated and if `false`, the element must be removed from the collection, and the `add` performed again.

Best regards,
Victor Ott

