### PR TITLE
acme-store-rest-nosql: Fix for IntelliJ complaining when syncing the pom.xml again after adding …

### DIFF
--- a/acme-store-rest-nosql/pom.xml
+++ b/acme-store-rest-nosql/pom.xml
@@ -8,6 +8,7 @@
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
         <version>2.4.1</version>
+        <relativePath/>
     </parent>
 
     <groupId>com.a4j</groupId>


### PR DESCRIPTION
…modifications to it: "'parent.relativePath' of POM com.a4j:acme-store-rest-nosql:1.0-SNAPSHOT (.../helidon-microstream-training-labs-foundation/acme-store-rest-nosql/pom.xml) points at com.a4j:parent instead of io.helidon.applications:helidon-mp, please verify your project structure"